### PR TITLE
Mirror of square picasso#1623

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
@@ -21,6 +21,7 @@ import android.view.View.OnAttachStateChangeListener;
 import android.view.ViewTreeObserver;
 import android.view.ViewTreeObserver.OnPreDrawListener;
 import android.widget.ImageView;
+
 import java.lang.ref.WeakReference;
 
 class DeferredRequestCreator implements OnPreDrawListener, OnAttachStateChangeListener {
@@ -72,7 +73,13 @@ class DeferredRequestCreator implements OnPreDrawListener, OnAttachStateChangeLi
     vto.removeOnPreDrawListener(this);
     this.target.clear();
 
-    this.creator.unfit().resize(width, height).into(target, callback);
+    this.creator.unfit().resize(width, height);
+    if (this.creator.doOnlyScaleDown) {
+      this.creator.onlyScaleDown();
+    }
+
+    this.creator.into(target, callback);
+
     return true;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -22,7 +22,9 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.Px;
 import android.view.Gravity;
+
 import com.squareup.picasso.Picasso.Priority;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -391,7 +393,8 @@ public final class Request {
      */
     public Builder onlyScaleDown() {
       if (targetHeight == 0 && targetWidth == 0) {
-        throw new IllegalStateException("onlyScaleDown can not be applied without resize");
+        throw new IllegalStateException(
+                "onlyScaleDown can not be applied without either calling resize or fit");
       }
       onlyScaleDown = true;
       return this;

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -305,7 +305,7 @@ public class RequestCreator {
    * Sets the stable key for this request to be used instead of the URI or resource ID when
    * caching. Two requests with the same value are considered to be for the same resource.
    */
-  public RequestCreator stableKey(@NonNull String stableKey) {
+  public RequestCreator stableKey(@Nullable String stableKey) {
     data.stableKey(stableKey);
     return this;
   }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -29,6 +29,7 @@ import android.support.annotation.VisibleForTesting;
 import android.view.Gravity;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,6 +61,7 @@ public class RequestCreator {
 
   private boolean noFade;
   private boolean deferred;
+  boolean doOnlyScaleDown;
   private boolean setPlaceholder = true;
   private int placeholderResId;
   private int errorResId;
@@ -268,7 +270,11 @@ public class RequestCreator {
    * specified by {@link #resize(int, int)}.
    */
   public RequestCreator onlyScaleDown() {
-    data.onlyScaleDown();
+    if (!deferred) {
+      data.onlyScaleDown();
+    } else {
+      doOnlyScaleDown = true;
+    }
     return this;
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -529,6 +529,7 @@ public class RequestCreatorTest {
   public void intoRemoteViewsWidgetWithFitThrows() {
     try {
       RemoteViews remoteViews = mockRemoteViews();
+      //noinspection ResourceType
       new RequestCreator(picasso, URI_1, 0).fit().into(remoteViews, 1, new int[] { 1, 2, 3 });
       fail("Calling fit() into remote views should throw exception");
     } catch (IllegalStateException ignored) {
@@ -539,6 +540,7 @@ public class RequestCreatorTest {
   public void intoRemoteViewsNotificationWithFitThrows() {
     try {
       RemoteViews remoteViews = mockRemoteViews();
+      //noinspection ResourceType
       new RequestCreator(picasso, URI_1, 0).fit().into(remoteViews, 1, 1, mockNotification());
       fail("Calling fit() into remote views should throw exception");
     } catch (IllegalStateException ignored) {
@@ -705,11 +707,13 @@ public class RequestCreatorTest {
     } catch (IllegalArgumentException ignored) {
     }
     try {
+      //noinspection ResourceType
       new RequestCreator().placeholder(1).placeholder(new ColorDrawable(0));
       fail("Two placeholders should throw exception.");
     } catch (IllegalStateException ignored) {
     }
     try {
+      //noinspection ResourceType
       new RequestCreator().placeholder(new ColorDrawable(0)).placeholder(1);
       fail("Two placeholders should throw exception.");
     } catch (IllegalStateException ignored) {
@@ -723,11 +727,13 @@ public class RequestCreatorTest {
     } catch (IllegalStateException ignored) {
     }
     try {
+      //noinspection ResourceType
       new RequestCreator().noPlaceholder().placeholder(1);
       fail("Placeholder after no placeholder should throw exception.");
     } catch (IllegalStateException ignored) {
     }
     try {
+      //noinspection ResourceType
       new RequestCreator().placeholder(1).noPlaceholder();
       fail("No placeholder after placeholder should throw exception.");
     } catch (IllegalStateException ignored) {
@@ -751,11 +757,13 @@ public class RequestCreatorTest {
     } catch (IllegalArgumentException ignored) {
     }
     try {
+      //noinspection ResourceType
       new RequestCreator().error(1).error(new ColorDrawable(0));
       fail("Two placeholders should throw exception.");
     } catch (IllegalStateException ignored) {
     }
     try {
+      //noinspection ResourceType
       new RequestCreator().error(new ColorDrawable(0)).error(1);
       fail("Two placeholders should throw exception.");
     } catch (IllegalStateException ignored) {

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -20,10 +20,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +29,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
@@ -547,12 +549,17 @@ public class RequestCreatorTest {
   public void intoTargetNoResizeWithCenterInsideOrCenterCropThrows() {
     try {
       new RequestCreator(picasso, URI_1, 0).centerInside().into(mockTarget());
-      fail("Center inside with unknown width should throw exception.");
+      fail("Center inside with unknown height/width should throw exception.");
     } catch (IllegalStateException ignored) {
     }
     try {
       new RequestCreator(picasso, URI_1, 0).centerCrop().into(mockTarget());
-      fail("Center inside with unknown height should throw exception.");
+      fail("Center inside with unknown height/width should throw exception.");
+    } catch (IllegalStateException ignored) {
+    }
+    try {
+      new RequestCreator(picasso, URI_1, 0).onlyScaleDown().into(mockTarget());
+      fail("Only scale down with unknown height/width should throw exception.");
     } catch (IllegalStateException ignored) {
     }
   }


### PR DESCRIPTION
Mirror of square picasso#1623
Resolves #941 

This pull request adds a boolean flag that is used to identify if calling `onlyScaleDown` was requested. When the fit() call resizes the request, the `doOnlyScaleDown` boolean flag is checked and the `onlyScaleDown` method may be called.

I also performed minor changes in the test file that I modified, namely adding error suppression for obviously intentional lines of code.

I have accepted the Square CLA.
