### PR TITLE
Mirror of square picasso#1269

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.media.ExifInterface;
 import android.net.Uri;
 import android.provider.MediaStore;
 import java.io.IOException;
@@ -108,10 +109,21 @@ class MediaStoreRequestHandler extends ContentStreamRequestHandler {
       if (cursor == null || !cursor.moveToFirst()) {
         return 0;
       }
-      return cursor.getInt(0);
+
+      int rotation = cursor.getInt(0);
+      switch (rotation) {
+        case 90:
+          return ExifInterface.ORIENTATION_ROTATE_90;
+        case 180:
+          return ExifInterface.ORIENTATION_ROTATE_180;
+        case 270:
+          return ExifInterface.ORIENTATION_ROTATE_270;
+        default:
+          return ExifInterface.ORIENTATION_NORMAL;
+      }
     } catch (RuntimeException ignored) {
       // If the orientation column doesn't exist, assume no rotation.
-      return 0;
+      return ExifInterface.ORIENTATION_UNDEFINED;
     } finally {
       if (cursor != null) {
         cursor.close();

--- a/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.media.ExifInterface;
 import android.net.NetworkInfo;
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,11 +56,13 @@ public abstract class RequestHandler {
     private final int exifOrientation;
 
     public Result(Bitmap bitmap, Picasso.LoadedFrom loadedFrom) {
-      this(checkNotNull(bitmap, "bitmap == null"), null, loadedFrom, 0);
+      this(checkNotNull(bitmap, "bitmap == null"), null, loadedFrom,
+              ExifInterface.ORIENTATION_UNDEFINED);
     }
 
     public Result(InputStream stream, Picasso.LoadedFrom loadedFrom) {
-      this(null, checkNotNull(stream, "stream == null"), loadedFrom, 0);
+      this(null, checkNotNull(stream, "stream == null"), loadedFrom,
+              ExifInterface.ORIENTATION_UNDEFINED);
     }
 
     Result(Bitmap bitmap, InputStream stream, Picasso.LoadedFrom loadedFrom, int exifOrientation) {
@@ -93,6 +96,8 @@ public abstract class RequestHandler {
     /**
      * Returns the resulting EXIF orientation generated from a {@link #load(Request, int)} call.
      * This is only accessible to built-in RequestHandlers.
+     *
+     * @return MUST return one from values defined as android.media.ExifInterface.ORIENTATION_*
      */
     int getExifOrientation() {
       return exifOrientation;


### PR DESCRIPTION
Mirror of square picasso#1269
MediaStoreRequestHandler: read MediaStore.Image.ORIENTATION value and translate it to ExifInterface.ORIENTATION_\* value.

Picasso determines orientation according to ExifInterface.ORIENTATION__. All possible values in MediaStore.Image.ORIENTATION are: 0, 90, 180, 270 (according to: https://developer.android.com/reference/android/provider/MediaStore.Images.ImageColumns.html#ORIENTATION). The values differ, thus orientation read from MediaStore must be translated to ExifInterface.ORIENTATION__ value.

Updated RequestHandler::getExifOrientation description.

