### PR TITLE
Mirror of square picasso#538

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/AndroidFaceDetector.java
+++ b/picasso/src/main/java/com/squareup/picasso/AndroidFaceDetector.java
@@ -1,0 +1,46 @@
+package com.squareup.picasso;
+
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import android.graphics.PointF;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AndroidFaceDetector implements FaceDetector {
+
+  @Override
+  public List<Face> findFaces(Bitmap source, int maxFaces) {
+    int faceCount;
+    List<Face> outFaces = new ArrayList<Face>();
+    if (source == null) {
+      return outFaces;
+    }
+
+    int w = source.getWidth();
+    int h = source.getHeight();
+    final float faceUpperRatio = 1.2f;
+    final float faceWidthFactor = 2.2f;
+    final float faceHeightFactor = 2.7f;
+
+    android.media.FaceDetector faceDetector = new android.media.FaceDetector(w, h, maxFaces);
+    android.media.FaceDetector.Face[] faces = new android.media.FaceDetector.Face[maxFaces];
+    faceCount = faceDetector.findFaces(source, faces);
+    PointF holder = new PointF();
+    float eyeDistance;
+    for (int i = 0; i < faceCount; i++) {
+      if (faces[i] == null) {
+        continue;
+      }
+      eyeDistance = faces[i].eyesDistance();
+      faces[i].getMidPoint(holder);
+      Point leftTopPoint =
+          new Point(Math.max(0, (int) holder.x - ((int) (eyeDistance * faceWidthFactor) / 2)),
+              Math.max(0, (int) holder.y - (int) (eyeDistance * faceUpperRatio)));
+      outFaces.add(
+          new Face((int) (eyeDistance * faceWidthFactor), (int) (eyeDistance * faceHeightFactor),
+              leftTopPoint)
+      );
+    }
+    return outFaces;
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso/FaceDetector.java
+++ b/picasso/src/main/java/com/squareup/picasso/FaceDetector.java
@@ -1,0 +1,31 @@
+package com.squareup.picasso;
+
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import java.util.List;
+
+public interface FaceDetector {
+  /**
+   * Find faces within bitmap
+   *
+   * @param source input bitmap, would not be recycled in function
+   * @param maxFaces max faces for face detector in bitmap
+   * @return face detected result
+   */
+  List<Face> findFaces(Bitmap source, int maxFaces);
+
+  /**
+   * A generic Face definition class for {@link FaceDetector}
+   */
+  public static class Face {
+    public final Point leftTopPoint;
+    public final int width;
+    public final int height;
+
+    public Face(int width, int height, Point leftTopPoint) {
+      this.width = width;
+      this.height = height;
+      this.leftTopPoint = leftTopPoint;
+    }
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -98,6 +98,11 @@ public class RequestCreator {
     this.data = new Request.Builder(null, 0);
   }
 
+  @TestOnly RequestCreator(FaceDetector faceDetector) {
+    this.picasso = new Picasso(faceDetector);
+    this.data = new Request.Builder(null, 0);
+  }
+
   /**
    * A placeholder drawable to be used while the image is being loaded. If the requested image is
    * not immediately available in the memory cache then this resource will be set on the target
@@ -201,20 +206,10 @@ public class RequestCreator {
    * specific {@link com.squareup.picasso.FaceDetector}.
    * If tha image had no faces, the result would be equal to centerCrop
    */
-  public RequestCreator faceCenterCrop(FaceDetector faceDetector) {
-    data.faceCenterCrop();
-    data.setFaceDetector(faceDetector);
-    return this;
-  }
-
-  /**
-   * Crops an image inside of the bounds specified by {@link #resize(int, int)}
-   * rather than distorting the aspect ratio which is according to faces
-   * detected by the default Android built-in face detector.
-   * If tha image had no faces, the result would be equal to centerCrop
-   */
   public RequestCreator faceCenterCrop() {
-    return faceCenterCrop(new AndroidFaceDetector());
+    data.faceCenterCrop();
+    data.setFaceDetector(picasso.faceDetector);
+    return this;
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -18,7 +18,6 @@ package com.squareup.picasso;
 import android.app.Notification;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.widget.ImageView;
@@ -194,6 +193,28 @@ public class RequestCreator {
   public RequestCreator centerCrop() {
     data.centerCrop();
     return this;
+  }
+
+  /**
+   * Crops an image inside of the bounds specified by {@link #resize(int, int)}
+   * rather than distorting the aspect ratio.according to faces detected by the
+   * specific {@link com.squareup.picasso.FaceDetector}.
+   * If tha image had no faces, the result would be equal to centerCrop
+   */
+  public RequestCreator faceCenterCrop(FaceDetector faceDetector) {
+    data.faceCenterCrop();
+    data.setFaceDetector(faceDetector);
+    return this;
+  }
+
+  /**
+   * Crops an image inside of the bounds specified by {@link #resize(int, int)}
+   * rather than distorting the aspect ratio which is according to faces
+   * detected by the default Android built-in face detector.
+   * If tha image had no faces, the result would be equal to centerCrop
+   */
+  public RequestCreator faceCenterCrop() {
+    return faceCenterCrop(new AndroidFaceDetector());
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -187,6 +187,8 @@ final class Utils {
       builder.append("centerCrop\n");
     } else if (data.centerInside) {
       builder.append("centerInside\n");
+    } else if (data.faceCenterCrop) {
+      builder.append("faceCenterCrop\n");
     }
 
     if (data.transformations != null) {

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -19,9 +19,12 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
+import android.graphics.Point;
 import android.net.Uri;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.FutureTask;
 import org.junit.Before;
 import org.junit.Test;
@@ -490,6 +493,298 @@ public class BitmapHunterTest {
     assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
   }
 
+  @Test public void faceCenterCropTallTooSmall() throws Exception {
+    Bitmap source = Bitmap.createBitmap(20, 40, ARGB_8888);
+    Bitmap result = null;
+    Request data = null;
+    Matrix matrix = null;
+    ShadowBitmap shadowBitmap = null;
+    ShadowMatrix shadowMatrix = null;
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(0))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(10);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(2))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(-1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(10);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+  }
+
+  @Test public void faceCenterCropTallTooLarge() throws Exception {
+    Bitmap source = Bitmap.createBitmap(200, 400, ARGB_8888);
+    Bitmap result = null;
+    Request data = null;
+    Matrix matrix = null;
+    ShadowBitmap shadowBitmap = null;
+    ShadowMatrix shadowMatrix = null;
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(0))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(100);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(2))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(-1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(100);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+  }
+
+  @Test public void faceCenterCropWideTooSmall() throws Exception {
+    Bitmap source = Bitmap.createBitmap(40, 20, ARGB_8888);
+    Bitmap result = null;
+    Request data = null;
+    Matrix matrix = null;
+    ShadowBitmap shadowBitmap = null;
+    ShadowMatrix shadowMatrix = null;
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(0))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(10);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(2))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(-1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(10);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(20);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(20);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 2.0");
+    result.recycle();
+  }
+
+  @Test public void faceCenterCropWideTooLargel() throws Exception {
+    Bitmap source = Bitmap.createBitmap(400, 200, ARGB_8888);
+    Bitmap result = null;
+    Request data = null;
+    Matrix matrix = null;
+    ShadowBitmap shadowBitmap = null;
+    ShadowMatrix shadowMatrix = null;
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(0))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(100);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(2))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+
+    data = new Request.Builder(URI_1).resize(40, 40)
+        .setFaceDetector(new MockFacaDetector(-1))
+        .faceCenterCrop()
+        .build();
+    result = transformResult(data, source, 0);
+    shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+    assertThat(shadowBitmap.getCreatedFromX()).isEqualTo(100);
+    assertThat(shadowBitmap.getCreatedFromY()).isEqualTo(0);
+    assertThat(shadowBitmap.getCreatedFromWidth()).isEqualTo(200);
+    assertThat(shadowBitmap.getCreatedFromHeight()).isEqualTo(200);
+    matrix = shadowBitmap.getCreatedFromMatrix();
+    shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.2 0.2");
+    result.recycle();
+  }
+
   @Test public void centerInsideTallTooSmall() throws Exception {
     Bitmap source = Bitmap.createBitmap(20, 10, ARGB_8888);
     Request data = new Request.Builder(URI_1).resize(50, 50).centerInside().build();
@@ -596,6 +891,43 @@ public class BitmapHunterTest {
 
     @Override Bitmap decode(Request data) throws IOException {
       throw new OutOfMemoryError();
+    }
+  }
+
+  private static class MockFacaDetector implements FaceDetector {
+
+    private final int faceType;
+
+    public MockFacaDetector(int faceType) {
+      this.faceType = faceType;
+    }
+
+    @Override public List<Face> findFaces(Bitmap source, int maxFaces) {
+      int iWidth = source.getWidth();
+      int iHeight = source.getHeight();
+      int aspectRatio = iWidth / iHeight;
+      int faceSize = (int) (Math.min(iWidth, iHeight) / 4.0f);
+      int halfFaceSize = (int) ((Math.min(iWidth, iHeight) / 4.0f) * 0.5f);
+
+      Point oneFourthOfImage = aspectRatio < 1 ? new Point((int) (iWidth * 0.5f - halfFaceSize),
+          (int) (iHeight * 0.25f - halfFaceSize))
+          : new Point((int) (iWidth * 0.25f - halfFaceSize), (int) (iHeight * 0.5f - halfFaceSize));
+      Point halfOfImage = aspectRatio < 1 ? new Point((int) (iWidth * 0.5f - halfFaceSize),
+          (int) (iHeight * 0.5f - halfFaceSize))
+          : new Point((int) (iWidth * 0.5f - halfFaceSize), (int) (iHeight * 0.5f - halfFaceSize));
+      Point threeFourthOfImage = aspectRatio < 1 ? new Point((int) (iWidth * 0.5f - halfFaceSize),
+          (int) (iHeight * 0.75f - halfFaceSize))
+          : new Point((int) (iWidth * 0.75f - halfFaceSize), (int) (iHeight * 0.5f - halfFaceSize));
+
+      Face face1 = new Face(faceSize, faceSize, oneFourthOfImage);
+      Face face2 = new Face(faceSize, faceSize, halfOfImage);
+      Face face3 = new Face(faceSize, faceSize, threeFourthOfImage);
+      List<Face> faces = Arrays.asList(face1, face2, face3);
+      List<Face> noFace = null; // No face detected
+      if (faceType == -1) {
+        return noFace;
+      }
+      return Arrays.asList(faces.get(faceType));
     }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
@@ -77,8 +77,8 @@ public class ImageViewActionTest {
   @Test
   public void invokesTargetAndCallbackSuccessIfTargetIsNotNull() throws Exception {
     Picasso picasso =
-        new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
-            mock(Stats.class), false, false);
+        new Picasso(Robolectric.application, mock(Dispatcher.class), mock(FaceDetector.class),
+            Cache.NONE, null, IDENTITY, mock(Stats.class), false, false);
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
     ImageViewAction request =

--- a/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
@@ -51,6 +51,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class NetworkBitmapHunterTest {
 
   @Mock Picasso.Listener listener;
+  @Mock FaceDetector faceDetector;
   @Mock Cache cache;
   @Mock Stats stats;
   @Mock Dispatcher dispatcher;
@@ -62,7 +63,8 @@ public class NetworkBitmapHunterTest {
   @Before public void setUp() throws Exception {
     initMocks(this);
     context = mockContext();
-    picasso = new Picasso(context, dispatcher, cache, listener, transformer, stats, false, false);
+    picasso = new Picasso(context, dispatcher, faceDetector, cache, listener,
+        transformer, stats, false, false);
     when(downloader.load(any(Uri.class), anyBoolean())).thenReturn(mock(Downloader.Response.class));
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -58,6 +58,7 @@ public class PicassoTest {
 
   @Mock Context context;
   @Mock Downloader downloader;
+  @Mock FaceDetector faceDetector;
   @Mock Dispatcher dispatcher;
   @Mock Picasso.RequestTransformer transformer;
   @Mock Cache cache;
@@ -68,7 +69,9 @@ public class PicassoTest {
 
   @Before public void setUp() {
     initMocks(this);
-    picasso = new Picasso(context, dispatcher, cache, listener, transformer, stats, false, false);
+    picasso =
+        new Picasso(context, dispatcher, faceDetector, cache, listener, transformer, stats,
+            false, false);
   }
 
   @Test public void submitWithNullTargetInvokesDispatcher() throws Exception {
@@ -322,6 +325,19 @@ public class PicassoTest {
     try {
       new Picasso.Builder(context).downloader(downloader).downloader(downloader);
       fail("Setting Downloader twice should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void builderInvalidFaceDetector() throws Exception {
+    try {
+      new Picasso.Builder(context).faceDetector(null);
+      fail("Null face detector should throw exception.");
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      new Picasso.Builder(context).faceDetector(faceDetector).faceDetector(faceDetector);
+      fail("Setting face detector twice should throw exception.");
     } catch (IllegalStateException expected) {
     }
   }

--- a/picasso/src/test/java/com/squareup/picasso/RemoteViewsActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RemoteViewsActionTest.java
@@ -74,8 +74,8 @@ public class RemoteViewsActionTest {
   }
 
   private Picasso createPicasso() {
-    return new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
-        mock(Stats.class), false, false);
+    return new Picasso(Robolectric.application, mock(Dispatcher.class), mock(FaceDetector.class),
+        Cache.NONE, null, IDENTITY, mock(Stats.class), false, false);
   }
 
   static class TestableRemoteViewsAction extends RemoteViewsAction {

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -206,8 +206,8 @@ public class RequestCreatorTest {
   @Test
   public void intoImageViewWithQuickMemoryCacheCheckDoesNotSubmit() throws Exception {
     Picasso picasso =
-        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
-            mock(Stats.class), false, false));
+        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), mock(FaceDetector.class),
+            Cache.NONE, null, IDENTITY, mock(Stats.class), false, false));
     doReturn(BITMAP_1).when(picasso).quickMemoryCacheCheck(URI_KEY_1);
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
@@ -221,8 +221,8 @@ public class RequestCreatorTest {
   @Test
   public void intoImageViewSetsPlaceholderDrawable() throws Exception {
     Picasso picasso =
-        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
-            mock(Stats.class), false, false));
+        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), mock(FaceDetector.class),
+            Cache.NONE, null, IDENTITY, mock(Stats.class), false, false));
     ImageView target = mockImageViewTarget();
     Drawable placeHolderDrawable = mock(Drawable.class);
     new RequestCreator(picasso, URI_1, 0).placeholder(placeHolderDrawable).into(target);
@@ -234,8 +234,8 @@ public class RequestCreatorTest {
   @Test
   public void intoImageViewSetsPlaceholderWithResourceId() throws Exception {
     Picasso picasso =
-        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
-            mock(Stats.class), false, false));
+        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), mock(FaceDetector.class),
+            Cache.NONE, null, IDENTITY, mock(Stats.class), false, false));
     ImageView target = mockImageViewTarget();
     new RequestCreator(picasso, URI_1, 0).placeholder(R.drawable.picture_frame).into(target);
     verify(target).setImageResource(R.drawable.picture_frame);
@@ -462,7 +462,7 @@ public class RequestCreatorTest {
     } catch (IllegalStateException expected) {
     }
     try {
-      new RequestCreator().resize(10, 10).faceCenterCrop().centerCrop();
+      new RequestCreator(mock(FaceDetector.class)).resize(10, 10).faceCenterCrop().centerCrop();
       fail("Calling center crop after face center crop should throw exception.");
     } catch (IllegalStateException expected) {
     }
@@ -475,7 +475,7 @@ public class RequestCreatorTest {
     } catch (IllegalStateException expected) {
     }
     try {
-      new RequestCreator().resize(10, 10).faceCenterCrop().centerInside();
+      new RequestCreator(mock(FaceDetector.class)).resize(10, 10).faceCenterCrop().centerInside();
       fail("Calling center inside after face center crop should throw exception.");
     } catch (IllegalStateException expected) {
     }
@@ -483,20 +483,15 @@ public class RequestCreatorTest {
 
   @Test public void invalidFaceCenterCrop() throws Exception {
     try {
-      new RequestCreator().resize(10, 10).centerCrop().faceCenterCrop();
+      new RequestCreator(mock(FaceDetector.class)).resize(10, 10).centerCrop().faceCenterCrop();
       fail("Calling face center crop after center crop should throw exception.");
     } catch (IllegalStateException expected) {
     }
     try {
-      new RequestCreator().resize(10, 10).centerInside().faceCenterCrop();
+      new RequestCreator(mock(FaceDetector.class)).resize(10, 10).centerInside().faceCenterCrop();
       fail("Calling face center crop after center inside should throw exception.");
     } catch (IllegalStateException expected) {
     }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void nullFaceDetectorInvalid() throws Exception {
-    new RequestCreator().resize(10, 10).faceCenterCrop(null);
   }
 
   @Test public void invalidPlaceholderImage() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -461,14 +461,42 @@ public class RequestCreatorTest {
       fail("Calling center crop after center inside should throw exception.");
     } catch (IllegalStateException expected) {
     }
+    try {
+      new RequestCreator().resize(10, 10).faceCenterCrop().centerCrop();
+      fail("Calling center crop after face center crop should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
   }
 
   @Test public void invalidCenterInside() throws Exception {
     try {
-      new RequestCreator().resize(10, 10).centerInside().centerCrop();
+      new RequestCreator().resize(10, 10).centerCrop().centerInside();
       fail("Calling center inside after center crop should throw exception.");
     } catch (IllegalStateException expected) {
     }
+    try {
+      new RequestCreator().resize(10, 10).faceCenterCrop().centerInside();
+      fail("Calling center inside after face center crop should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void invalidFaceCenterCrop() throws Exception {
+    try {
+      new RequestCreator().resize(10, 10).centerCrop().faceCenterCrop();
+      fail("Calling face center crop after center crop should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      new RequestCreator().resize(10, 10).centerInside().faceCenterCrop();
+      fail("Calling face center crop after center inside should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nullFaceDetectorInvalid() throws Exception {
+    new RequestCreator().resize(10, 10).faceCenterCrop(null);
   }
 
   @Test public void invalidPlaceholderImage() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/TargetActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/TargetActionTest.java
@@ -72,8 +72,8 @@ public class TargetActionTest {
     Target target = mockTarget();
     Context context = mock(Context.class);
     Picasso picasso =
-        new Picasso(context, mock(Dispatcher.class), Cache.NONE, null, IDENTITY, mock(Stats.class),
-            false, false);
+        new Picasso(context, mock(Dispatcher.class), mock(FaceDetector.class), Cache.NONE, null,
+            IDENTITY, mock(Stats.class), false, false);
     Resources res = mock(Resources.class);
     TargetAction request =
         new TargetAction(picasso, target, null, false, RESOURCE_ID_1, null, URI_KEY_1);

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -144,9 +144,9 @@ class TestUtils {
     Context context = mockContext();
     when(context.checkCallingOrSelfPermission(Manifest.permission.INTERNET)).thenReturn(
         PERMISSION_GRANTED);
-    return new Picasso(context, mock(Dispatcher.class), mock(Cache.class),
-        mock(Picasso.Listener.class), mock(Picasso.RequestTransformer.class), mock(Stats.class),
-        false, false);
+    return new Picasso(context, mock(Dispatcher.class), mock(FaceDetector.class),
+        mock(Cache.class), mock(Picasso.Listener.class), mock(Picasso.RequestTransformer.class),
+        mock(Stats.class), false, false);
   }
 
   static Context mockContext() {


### PR DESCRIPTION
Mirror of square picasso#538
**New Feature**

Picasso is built-in with two types of cropping:  `centerInside()` and `centerCrop()`.  They work well for most images, but sometimes they can cut out faces that are not located in the center of images, producing undesirable thumbnails.

With the help of the native [`FaceDetector`](http://developer.android.com/reference/android/media/FaceDetector.html) in the Android framework, this pull request adds a new API to do what I call a `faceCenterCrop()`.  It crops an image so that faces detected in the image are kept intact as much as possible.  Like `centerCrop()` and `centerInside()`, the `resize()` API must be called together with `faceCenterCrop()`.  For instance,

``` java
Picasso.with(context)
       .load(url)
       .resize(targetWidth, targetHeight)
       .faceCenterCrop()
       .into(imageView)
```

However, the native `FaceDetector` API provided by the Android framework is slow.  You may provide your own implementation of the `FaceDetector`:in Picasso builder

``` java
Picasso.Builder(context)
       .memoryCache(cache)
       .faceDetector(new MyFaceDetector())
       .build();
```

