### PR TITLE
Mirror of square picasso#1601

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
@@ -73,7 +73,8 @@ class Dispatcher {
   static final int AIRPLANE_MODE_CHANGE = 10;
   static final int TAG_PAUSE = 11;
   static final int TAG_RESUME = 12;
-  static final int REQUEST_BATCH_RESUME = 13;
+  static final int TAG_REMOVE = 13;
+  static final int REQUEST_BATCH_RESUME = 14;
 
   private static final String DISPATCHER_THREAD_NAME = "Dispatcher";
   private static final int BATCH_DELAY = 200; // ms
@@ -148,6 +149,10 @@ class Dispatcher {
 
   void dispatchResumeTag(Object tag) {
     handler.sendMessage(handler.obtainMessage(TAG_RESUME, tag));
+  }
+
+  void dispatchRemoveTag(Object tag) {
+    handler.sendMessage(handler.obtainMessage(TAG_REMOVE, tag));
   }
 
   void dispatchComplete(BitmapHunter hunter) {
@@ -317,6 +322,10 @@ class Dispatcher {
     }
   }
 
+  void performRemoveTag(Object tag) {
+    pausedTags.remove(tag);
+  }
+
   void performRetry(BitmapHunter hunter) {
     if (hunter.isCancelled()) return;
 
@@ -479,6 +488,11 @@ class Dispatcher {
         case TAG_RESUME: {
           Object tag = msg.obj;
           dispatcher.performResumeTag(tag);
+          break;
+        }
+        case TAG_REMOVE: {
+          Object tag = msg.obj;
+          dispatcher.performRemoveTag(tag);
           break;
         }
         case HUNTER_COMPLETE: {

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -265,6 +265,8 @@ public class Picasso {
         deferredRequestCreator.cancel();
       }
     }
+
+    dispatcher.dispatchRemoveTag(tag);
   }
 
   /**

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -445,6 +445,13 @@ public class DispatcherTest {
     assertThat(dispatcher.pausedTags).isEmpty();
   }
 
+  @Test public void performPauseAndRemoveUpdatesListOfPausedTags() {
+    dispatcher.performPauseTag("tag");
+    assertThat(dispatcher.pausedTags).hasSize(1).contains("tag");
+    dispatcher.performRemoveTag("tag");
+    assertThat(dispatcher.pausedTags).isEmpty();
+  }
+
   @Test public void performPauseTagIsIdempotent() {
     Action action = mockAction(URI_KEY_1, URI_1, mockTarget(), "tag");
     BitmapHunter hunter = mockHunter(URI_KEY_1, bitmap1, false, action);


### PR DESCRIPTION
Mirror of square picasso#1601
If tag methods are called in the following order (ex. according to Activity Lifecycle)
resumeTag("TAG") => pauseTag("TAG") => cancelTag("TAG")

"Set<Object> pausedTags" in Dispatcher class still have tag object after cancelTag().
If tag is activity, activity leak occurs.

So I added to remove tag in pausedTags when cancelTag() is called.

Thanks
